### PR TITLE
Add generic to HandlerFunc

### DIFF
--- a/konva.d.ts
+++ b/konva.d.ts
@@ -5,10 +5,10 @@ declare namespace Konva {
   var isDragReady: () => boolean;
   var DD: any;
 
-  type HandlerFunc = (
+  type HandlerFunc<E = Event> = (
     e: {
       target: Konva.Shape;
-      evt: Event;
+      evt: E;
       currentTarget: Konva.Node;
       cancelBubble: boolean;
     }


### PR DESCRIPTION
I suggest to add generic to `HandlerFunc` for `evt`. The default type is `Event`.